### PR TITLE
Fix for versions 3.12.0 to 3.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,14 @@ If you are using CEVFS, chances are that you are _not_ currently making use of t
 - Free nodes are not managed which could result in wasted space. Not an issue if the database you create with `cevfs_build()` is intended to be used as a read-only database.
 - VACUUM not yet implemented to recover lost space.
 
-## Knows Issues
-1. Does not work yet with SQLite version 3.13.0.
+## Compatible Versions
+
+|Version|Combatibility|
+|-|-|
+|3.10.2|Most development was originally on this version|
+|3.11.x|OK|
+|3.12.0 - 3.15.2|CEVFS recently fixed for these versions|
+|3.16.0 and higher|Not compatible yet due to API changes|
 
 ## Contributing to the project
 If you would like to contribute back to the project, please fork the repo and submit pull requests. For more information, please read this [wiki page](https://github.com/ryanhomer/sqlite3-compression-encryption-vfs/wiki/Developing-in-Xcode)


### PR DESCRIPTION
Now uses the correct page size of the upper pager instead of relying on the default value which changed with version 3.12.0